### PR TITLE
Add name, dir opts; escape quoted args

### DIFF
--- a/bin/orgwide-init
+++ b/bin/orgwide-init
@@ -33,7 +33,9 @@ type poirot >/dev/null 2>&1 || {
 usage(){
     echo -e "\nUsage:\n 18f init [options]\n"
     echo "  Options:"
+    echo "  -d, --dir     Repository location (defaults to current directory)"
     echo "  -h, --help    Display this help message"
+    echo "  -n, --name    Project name (defaults to current directory name)"
     echo ""
 }
 

--- a/bin/orgwide-init
+++ b/bin/orgwide-init
@@ -31,18 +31,24 @@ type poirot >/dev/null 2>&1 || {
 }
 
 usage(){
-	echo -e "\nUsage:\n 18f init [options]\n"
-  echo "  Options:"
-  echo "  -h, --help    Display this help message"
-	echo ""
+    echo -e "\nUsage:\n 18f init [options]\n"
+    echo "  Options:"
+    echo "  -h, --help    Display this help message"
+    echo ""
 }
 
 # Convert known long options to short options
 for arg in "$@"; do
   shift
   case "$arg" in
+    --dir)
+      set -- "$@" "-d"
+      ;;
     --help)
       set -- "$@" "-h"
+      ;;
+    --name)
+      set -- "$@" "-n"
       ;;
     --quiet)
       set -- "$@" "-q"
@@ -56,23 +62,33 @@ done
 OPTIND=1
 
 # Process option flags
-while getopts ":hq" opt; do
-	case "$opt" in
-		h )
-			usage
-			exit 0
-			;;
+while getopts "d:hqn:" opt; do
+  case $opt in
+    d )
+      HERE="$OPTARG"
+      ;;
+    h )
+      usage
+      exit 0
+      ;;
+    n )
+      NAME="$OPTARG"
+      ;;
     q )
       exec 1>/dev/null 2>/dev/null
       ;;
-		\? )
-			echo "Unrecognized option: -$OPTARG\n"
-			usage
-			exit 1
-			;;
-	esac
+    \? )
+      echo "Unrecognized option: -$OPTARG\n"
+      usage
+      exit 1
+      ;;
+  esac
 done
 shift $((OPTIND -1))
+
+# Create project directory, if doesn't already exist, and move there
+mkdir -p "$HERE"
+cd "$HERE"
 
 # Initialize git repo in this directory
 git init >/dev/null
@@ -97,7 +113,7 @@ git checkout -b develop >/dev/null 2>&1
 
 # Create initial .about.yml
 echo "|| Initializing .about.yml"
-about_yml_generate > $HERE/.about.yml
+about_yml_generate > .about.yml
 
 # Install git hooks
 echo "|| Adding Poirot to git hooks"

--- a/orgwide
+++ b/orgwide
@@ -47,8 +47,13 @@ shift $((OPTIND -1))
 # Find subcommands and subcommand arguments
 SUB=$1; shift
 for var in "$@"; do
-	ARGS+="$var "
+	if [[ $var == \-* ]]
+	then
+		ARGS+="$var "
+	else
+		ARGS+="\"$var\" "
+	fi
 done
 
 # Send to subcommand
-${CMD}-${SUB} ${ARGS}
+eval "${CMD}-${SUB} ${ARGS}"


### PR DESCRIPTION
Adds name (-n, —name) and dir (-d, —dir) opts for init script.

Escapes quotes on args to preserve arg values with spaces.

h\t @benjaminrosenbaum 

Don’t think the eval in orgwide is objectionable in this case. Perhaps there’s a better way of preserving spaces, though..