### PR TITLE
Remove `develop` branch checkout

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -159,9 +159,6 @@ else
   done
 fi
 
-# Establish git branches
-git checkout -b develop >/dev/null 2>&1
-
 # Create initial .about.yml
 if [[ ! -e .about.yml ]] || [[ $FORCE ]]; then
   echo " Initializing .about.yml"


### PR DESCRIPTION
Per 18F/open-source-policy#56, don't promote a `master`/`develop` strategy in the init script, either
