### PR TITLE
Add "gitignores" scaffold.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,12 @@ yo 18f            # all generators
 # or individually:
 yo 18f:license
 yo 18f:readme
+yo 18f:gitignores
 ```
 
 ### License
+
+Pulls file content from https://github.com/18F/open-source-policy
 
 ```sh
 $ yo 18f:license
@@ -118,6 +121,9 @@ $ tree
 
 ### Readme
 
+Pulls README content from
+https://github.com/18F/open-source-policy/blob/master/README_TEMPLATE.md
+
 ```sh
 $ yo 18f:readme
 ? What is the project's full name? My Project
@@ -125,4 +131,21 @@ $ yo 18f:readme
 $ tree
 .
 └── README.md
+```
+
+### Gitignores
+
+Pulls Gitignore content from https://github.com/github/gitignore
+
+```sh
+$ yo 18f:readme
+? What languages will this project use?
+ ◯ Go
+ ◉ Node
+ ◯ Python
+❯◉ Ruby
+
+$ tree
+.
+└── .gitignore
 ```

--- a/app/index.js
+++ b/app/index.js
@@ -5,6 +5,7 @@ module.exports = Generator.extend({
   initializing: function () {
     this.composeWith(require.resolve('../license'));
     this.composeWith(require.resolve('../readme'));
+    this.composeWith(require.resolve('../gitignores'));
     this.composeWith(require.resolve('../npm'));
   }
 });

--- a/gitignores/index.js
+++ b/gitignores/index.js
@@ -1,0 +1,47 @@
+'use strict';
+var axios = require('axios');
+var Generator = require('yeoman-generator');
+var languages = require('../languages');
+
+function fetchGitignore(language, fs, gitignorePath) {
+  var url = 'https://raw.githubusercontent.com/github/gitignore/master/';
+  url += language + '.gitignore';
+
+  return axios.get(url).then(function (response) {
+    var fileContents = fs.read(gitignorePath, {defaults: ''});
+    fileContents += '\n\n# === ' + language + ' ===\n' + response.data;
+    fs.write(gitignorePath, fileContents);
+  });
+};
+
+module.exports = Generator.extend({
+  prompting: function () {
+    return this.prompt(languages.promptFor(this.config)).then(
+        languages.saveResultsTo(this.config));
+  },
+  languagesAlreadyPresent: function() {
+    var languages = new Set();
+    var filePath = this.destinationPath('.gitignore');
+    var fileContents = this.fs.read(filePath, {defaults: ''});
+    var search = /^# === ([^=]+) ===$/gm;
+    var match = search.exec(fileContents);
+
+    while (match !== null) {
+      languages.add(match[1]);
+      match = search.exec(fileContents);
+    }
+    return languages;
+  },
+  writing: function () {
+    var existingLanguages = this.languagesAlreadyPresent();
+    var requests = this.config.get('languages').filter(function(language) {
+      return !existingLanguages.has(language);
+    }).map(function(language) {
+      return fetchGitignore(
+        language, this.fs, this.destinationPath('.gitignore')
+      );
+    }.bind(this));
+    return Promise.all(requests);
+  }
+});
+

--- a/languages/index.js
+++ b/languages/index.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var supportedLanguages = ['Go', 'Node', 'Python', 'Ruby'];
+var prompt = {
+  type: 'checkbox',
+  name: 'languages',
+  message: 'What languages will this project use?',
+  choices: supportedLanguages.map(function(l) { return {name: l}; })
+}
+
+module.exports = {
+  supportedLanguages: supportedLanguages,
+  promptFor: function(config) {
+    if (!config.get('languages')) {
+      return [prompt];
+    }
+    return [];
+  },
+  saveResultsTo: function(config) {
+    return function(props) {
+      if (props.languages) {
+        config.set('languages', props.languages);
+      }
+    }
+  },
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "files": [
     "app",
     "license",
+    "gitignores",
     "npm",
     "readme"
   ],


### PR DESCRIPTION
This pulls gitignore content from Github's big
[list](https://github.com/github/gitignore). It also defines a shared variable
around languages (many of our scaffolds will need to know which languages the
project supports). After selecting languages, the question won't be asked
again (unless the user deletes the entry in their .yo-rc).

Perhaps contentious here: I selected four languages (Go, Node, Python, Ruby)
for us to claim to support. I'd argue that other languages are certainly
possible (and easily doable for gitignores, for example), but that we'll want
to only promise scaffolds for a subset. It's also necessary to prevent an
obnoxiously long list for the user to select from.

Should resolve #24 