### PR TITLE
about.yml generator (depends on shared-config)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true,
+        "node": true
+    },
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": false
+        },
+        "sourceType": "module"
+    },
+    "rules": {
+        "no-const-assign": "warn",
+        "no-this-before-super": "warn",
+        "no-undef": "warn",
+        "no-unreachable": "warn",
+        "no-unused-vars": "warn",
+        "constructor-super": "warn",
+        "valid-typeof": "warn"
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 orgname
+node_modules/

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+    "node": true,
+    "esversion": 6
+}

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ yo 18f:readme
 yo 18f:gitignores
 yo 18f:npm
 yo 18f:cf-manifest
+yo 18f:about-yml
 ```
 
 ### License
@@ -193,4 +194,38 @@ $ tree
 .
 ├── TODO.txt
 └── Procfile
+```
+
+## About.yml
+
+Creates an .about.yml file (used in the ATO process).
+
+```sh
+$ yo 18f:about-yml
+? What's the repo name? (A short name that acts as the project identifier) @TODO
+? What's the project title? (A few words, title cased, describing the project) @TODO
+? What is the problem your project solves? What is the solution? @TODO
+? What is the measurable impact of your project? @TODO
+? What is your project's current status? (Use arrow keys)
+❯ discovery
+  alpha
+  beta
+  live
+? Will your project have automated tests? (Y/n)
+? What type of content is being stored in the repo? (Use arrow keys)
+❯ app
+  docs
+  policy
+? What kind of group owns this repo? (Use arrow keys)
+❯ project
+  working-group
+  guild
+? Who is the primary partner for the project? (Use the full name documented here: https://github.com/18F/dashboard/blob/staging/_data/partners.yml ) @TODO
+? Who is the primary team contact for the project? @TODO
+? What is the primary team contact's email address? @TODO
+? If this is a sub-repo of another repo, what is the name of that parent repo?  @TODO
+
+$ tree
+.
+└── .about.yml
 ```

--- a/about-yml/index.js
+++ b/about-yml/index.js
@@ -88,13 +88,7 @@ var prompts = [
 module.exports = Generator.extend({
   prompting: function() {
     return this.prompt(prompts
-      .filter( (prompt) => {
-        if (this.config.get(prompt.name)) {
-          return false;
-        } else {
-          return true;
-        }
-      })
+      .filter( prompt => !this.config.get(prompt.name))
       .map( (prompt) => {
         if (prompt.type === 'input' && !prompt.default) {
           prompt['default'] = '@TODO';

--- a/about-yml/index.js
+++ b/about-yml/index.js
@@ -1,12 +1,15 @@
 'use strict';
 
+var path = require('path');
+
 var Generator = require('yeoman-generator');
 
 var prompts = [
   {
     type: 'input',
     name: 'repoName',
-    message: 'What\'s the repo name? (A short name that acts as the project identifier)'
+    message: 'What\'s the repo name? (A short name that acts as the project identifier)',
+    default: process.cwd().split(path.sep).pop()
   },
 
   {
@@ -55,7 +58,7 @@ var prompts = [
     choices: ['project', 'working-group', 'guild']
   },
 
-  { 
+  {
     type: 'input',
     name: 'partner',
     message: 'Who is the primary partner for the project? (Use the full name documented here: https://github.com/18F/dashboard/blob/staging/_data/partners.yml )'
@@ -97,7 +100,7 @@ module.exports = Generator.extend({
           prompt['default'] = '@TODO';
         }
         return prompt;
-      }) 
+      })
     ).then( (props) => {
       Object.keys(props).forEach((key) => {
         if (props[key]) {

--- a/about-yml/index.js
+++ b/about-yml/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var Generator = require('yeoman-generator');
+const Generator = require('yeoman-generator');
+const sharedConfig = require('../shared-config');
 
 var prompts = [
   {
@@ -108,7 +109,7 @@ module.exports = Generator.extend({
     this.fs.copyTpl(
       this.templatePath('about.yml'),
       this.destinationPath('.about.yml'),
-      this.config.getAll()
+      Object.assign({}, this.config.getAll(), sharedConfig)
     );
 
   }

--- a/about-yml/index.js
+++ b/about-yml/index.js
@@ -1,0 +1,118 @@
+'use strict';
+
+var Generator = require('yeoman-generator');
+
+var prompts = [
+  {
+    type: 'input',
+    name: 'repoName',
+    message: 'What\'s the repo name? (A short name that acts as the project identifier)'
+  },
+
+  {
+    type: 'input',
+    name: 'projectFullName',
+    message: 'What\'s the project title? (A few words, title cased, describing the project)'
+  },
+
+  {
+    type: 'input',
+    name: 'description',
+    message: 'What is the problem your project solves? What is the solution?'
+  },
+
+  {
+    type: 'input',
+    name: 'impact',
+    message: 'What is the measurable impact of your project?'
+  },
+
+  {
+    type: 'list',
+    name: 'stage',
+    message: 'What is your project\'s current status?',
+    choices: ['discovery', 'alpha', 'beta', 'live']
+  },
+
+  {
+     type: 'confirm',
+     name: 'testable',
+     message: 'Will your project have automated tests?',
+     default: true
+  },
+
+  {
+    type: 'list',
+    name: 'type',
+    message: 'What type of content is being stored in the repo?',
+    choices: ['app', 'docs', 'policy']
+  },
+
+  {
+    type: 'list',
+    name: 'ownerType',
+    message: 'What kind of group owns this repo?',
+    choices: ['project', 'working-group', 'guild']
+  },
+
+  { 
+    type: 'input',
+    name: 'partner',
+    message: 'Who is the primary partner for the project? (Use the full name documented here: https://github.com/18F/dashboard/blob/staging/_data/partners.yml )'
+  },
+
+  {
+    type: 'input',
+    name: 'contactName',
+    message: 'Who is the primary team contact for the project?'
+  },
+
+  {
+    type: 'input',
+    name: 'contactEmail',
+    message: 'What is the primary team contact\'s email address?'
+  },
+
+  {
+    type: 'input',
+    name: 'parent',
+    message: 'If this is a sub-repo of another repo, what is the name of that parent repo?',
+    default: ''
+  }
+
+];
+
+module.exports = Generator.extend({
+  prompting: function() {
+    return this.prompt(prompts
+      .filter( (prompt) => {
+        if (this.config.get(prompt.name)) {
+          return false;
+        } else {
+          return true;
+        }
+      })
+      .map( (prompt) => {
+        if (prompt.type === 'input' && !prompt.default) {
+          prompt['default'] = '@TODO';
+        }
+        return prompt;
+      }) 
+    ).then( (props) => {
+      Object.keys(props).forEach((key) => {
+        if (props[key]) {
+          this.config.set(key, props[key]);
+        }
+      });
+    });
+  },
+
+  writing: function () {
+    this.fs.copyTpl(
+      this.templatePath('about.yml'),
+      this.destinationPath('.about.yml'),
+      this.config.getAll()
+    );
+
+  }
+});

--- a/about-yml/templates/about.yml
+++ b/about-yml/templates/about.yml
@@ -9,7 +9,7 @@
 name: <%= repoName %>
 
 # This is the display name of your project. (required)
-full_name: <%= projectFullName %> 
+full_name: <%= projectFullName %>
 
 # What is the problem your project solves? What is the solution? Use the
 # format shown below. The #dashboard team will gladly help you put this
@@ -41,7 +41,7 @@ testable: <%= testable %>
 #     url: URL for the text of the license
 licenses:
   <%= repoName %>:
-    name: CC0-1.0
+    name: <%= licenseShortName %>
     url: https://github.com/18f/<%= repoName %>/blob/master/LICENSE.md
 
 # Who is the partner for your project? (Use the full name of the partner
@@ -66,7 +66,7 @@ contact:
 #   id: Internal team identifier/user name
 #   role: Team member's role; leads should be designated as 'lead'
 team:
-- 
+-
 
 # What kind of content is contained in the project repository?
 # values: app, docs, policy
@@ -74,7 +74,7 @@ type: <%= type %>
 
 # What are the key milestones you've achieved recently?
 milestones:
-- 
+-
 
 # Name of the main project repo if this is a sub-repo; name of the grouplet
 # repo if this is a working group/guild subproject
@@ -87,16 +87,16 @@ parent: <%= parent %>
 #   text: Anchor text for the link
 #   category: Type of the link
 links:
-- 
+-
 
 # What tags does your organization's blog associate with your project? You can
 # find a list of 18F blog tags here: https://18f.gsa.gov/tags/
 blogTag:
-- 
+-
 
 # What technologies are used in this project?
 stack:
-- 
+-
 
 # What are the services used to supply project status information?
 # Items:
@@ -105,15 +105,15 @@ stack:
 #   url: URL for detailed information
 #   badge: URL for the status badge
 services:
-- 
+-
 
 # Organizations or individuals who have adopted the project for their own use
 # Items:
 # - id: The name of the organization or individual
 #   url: A URL to the user's version of the project
 users:
-- 
+-
 
 # Tags that describe the project or aspects of the project
 tags:
-- 
+-

--- a/about-yml/templates/about.yml
+++ b/about-yml/templates/about.yml
@@ -1,0 +1,119 @@
+---
+# .about.yml project metadata
+#
+# Copy this template into your project repository's root directory as
+# .about.yml and fill in the fields as described below.
+
+# This is a short name of your project that can be used as a URL slug.
+# (required)
+name: <%= repoName %>
+
+# This is the display name of your project. (required)
+full_name: <%= projectFullName %> 
+
+# What is the problem your project solves? What is the solution? Use the
+# format shown below. The #dashboard team will gladly help you put this
+# together for your project. (required)
+description: <%= description %>
+
+# What is the measurable impact of your project? Use the format shown below.
+# The #dashboard team will gladly help you put this together for your project.
+# (required)
+impact: <%= impact %>
+
+# What kind of team owns the repository? (required)
+# values: guild, working-group, project
+owner_type: <%= ownerType %>
+
+# What is your project's current status? (required)
+# values: discovery, alpha, beta, live
+stage: <%= stage %>
+
+# Should this repo have automated tests? If so, set to `true`. (required)
+# values: true, false
+testable: <%= testable %>
+
+# What are the licenses that apply to the project and/or its components?
+# (required)
+# Items by property name pattern:
+#   .*:
+#     name: Name of the license from the Software Package Data Exchange (SPDX): https://spdx.org/licenses/
+#     url: URL for the text of the license
+licenses:
+  <%= repoName %>:
+    name: CC0-1.0
+    url: https://github.com/18f/<%= repoName %>/blob/master/LICENSE.md
+
+# Who is the partner for your project? (Use the full name of the partner
+# documented here:
+# https://github.com/18F/dashboard/blob/staging/_data/partners.yml)
+partners:
+- <%= partner %>
+
+# The main point of contact(s) and/or the issue reporting system for your
+# project, and either a `mailto:` link or URL for each contact.
+# Items:
+# - url: URL for the link
+#   text: Anchor text for the link
+contact:
+- text: <%= contactName %>
+  url: mailto:<%= contactEmail %>
+
+# Who are the team members on your project? You can specify GitHub usernames,
+# email addresses, or other organizational usernames. (required)
+# Items:
+# - github: GitHub user name
+#   id: Internal team identifier/user name
+#   role: Team member's role; leads should be designated as 'lead'
+team:
+- 
+
+# What kind of content is contained in the project repository?
+# values: app, docs, policy
+type: <%= type %>
+
+# What are the key milestones you've achieved recently?
+milestones:
+- 
+
+# Name of the main project repo if this is a sub-repo; name of the grouplet
+# repo if this is a working group/guild subproject
+parent: <%= parent %>
+
+# What are the links to key artifacts associated with your project? e.g. the
+# production site, documentation.
+# Items:
+# - url: URL for the link
+#   text: Anchor text for the link
+#   category: Type of the link
+links:
+- 
+
+# What tags does your organization's blog associate with your project? You can
+# find a list of 18F blog tags here: https://18f.gsa.gov/tags/
+blogTag:
+- 
+
+# What technologies are used in this project?
+stack:
+- 
+
+# What are the services used to supply project status information?
+# Items:
+# - name: Name of the service
+#   category: Type of the service
+#   url: URL for detailed information
+#   badge: URL for the status badge
+services:
+- 
+
+# Organizations or individuals who have adopted the project for their own use
+# Items:
+# - id: The name of the organization or individual
+#   url: A URL to the user's version of the project
+users:
+- 
+
+# Tags that describe the project or aspects of the project
+tags:
+- 

--- a/app/index.js
+++ b/app/index.js
@@ -8,5 +8,6 @@ module.exports = Generator.extend({
     this.composeWith(require.resolve('../gitignores'));
     this.composeWith(require.resolve('../npm'));
     this.composeWith(require.resolve('../cf-manifest'));
+    this.composeWith(require.resolve('../about-yml'));    
   }
 });

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var Generator = require('yeoman-generator');
+const Generator = require('yeoman-generator');
+const sharedConfig = require('../shared-config');
 
 module.exports = Generator.extend({
   prompting: function() {
@@ -24,7 +25,7 @@ module.exports = Generator.extend({
         description: this.config.get('description'),
         repo: 'https://github.com/18F/' + this.config.get('repoName'),
         author: '18f',
-        license: 'CC0-1.0'
+        license: sharedConfig.licenseShortName
       });
     }
   }

--- a/npm/index.js
+++ b/npm/index.js
@@ -12,15 +12,17 @@ module.exports = Generator.extend({
       message : 'Will this project have front end libraries/dependencies',
       default : true
     }]).then((answers) => {
-      this.frontendDeps = answers.frontendDeps;
+      this.config.set('frontendDeps', answers.frontendDeps);
     });
   },
 
   configuring: function() {
-    if (this.frontendDeps) {
+    if (this.config.get('frontendDeps')) {
       this.log('Configuring npm now...');
       this.composeWith(require.resolve('generator-npm-init/app'), {
-        repo: 'https://github.com/18F/' + process.cwd().split(path.sep).pop(),
+        name: this.config.get('repoName'),
+        description: this.config.get('description'),
+        repo: 'https://github.com/18F/' + this.config.get('repoName'),
         author: '18f',
         license: 'CC0-1.0'
       });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "app",
+    "about-yml",
     "cf-manifest",
     "gitignores",
     "license",

--- a/shared-config/index.js
+++ b/shared-config/index.js
@@ -3,6 +3,7 @@
  * ask once.
  */
 
+const licenseShortName = 'CC0-1.0';
 const supportedLanguages = ['Go', 'Node', 'Python', 'Ruby'];
 const languagesPrompt = {
   type: 'checkbox',
@@ -38,6 +39,7 @@ module.exports = {
       });
     }
   },
+  licenseShortName,
   supportedLanguages,
   languagesPrompt,
   primaryLanguagePrompt,


### PR DESCRIPTION
Done with @msecret. Based on https://github.com/18F/about_yml . Note that since the `about.yml` file isn't used for much right now, we've skipped questions that seemed like too much work (mainly because they involved the user entering a list of items, e.g. URLs).

Also: this PR is branched from #49 but does not actually use any of the `shared-config` API. (We should probably discuss the best way to share config info.)