### PR TITLE
Fix 'gitignores' command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ tree
 Pulls Gitignore content from https://github.com/github/gitignore
 
 ```sh
-$ yo 18f:readme
+$ yo 18f:gitignores
 ? What languages will this project use?
  ◯ Go
  ◉ Node


### PR DESCRIPTION
Fixes a copy-pasta error, correcting the second instance of '18f:readme' to '18f:gitignores'.